### PR TITLE
Updated sha256 and paths in pyngl src [ci skip]

### DIFF
--- a/recipe/beta_version.patch
+++ b/recipe/beta_version.patch
@@ -1,5 +1,5 @@
---- pyngl-1.5.0_beta20161122.orig/src/version
-+++ pyngl-1.5.0_beta20161122/src/version
+--- pyngl-1.5.0_beta20161122.orig/version
++++ pyngl-1.5.0_beta20161122/version
 @@ -1 +1 @@
 -1.5.0
 +1.5.0_beta20161122

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -27,5 +27,4 @@ if [[ $(uname) == Darwin ]]; then
   export LDFLAGS="-headerpad_max_install_names $LDFLAGS"
 fi
 
-cd src
 python setup.py install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ package:
 source:
   fn: pyngl-{{ version }}.tar.gz
   url: https://github.com/NCAR/pyngl/archive/{{ version }}.tar.gz
-  sha256: 5b13af17d819d210e92d179a73f1323bc0feeeafefe55ded043b74462ebf712d
+  sha256: be530f5692ce4329322c432903d8d37daa39e695c40c10157492e576317b7270
   patches:
     - beta_version.patch
 
@@ -46,13 +46,13 @@ requirements:
 
 test:
   source_files:
-    - src/examples
+    - examples
   requires:
     - nose
   imports:
     - Ngl
   commands:
-    - cd src/examples && for file in xy2.py; do echo $file ; nosetests $file ; done | tee pyngl-test.log
+    - cd examples && for file in xy2.py; do echo $file ; nosetests $file ; done | tee pyngl-test.log
 
 about:
   home: http://pyngl.ucar.edu/


### PR DESCRIPTION
The PyNGL source code repository was recently restructured. Previously,
all source code was contained in a 'src' subdirectory, and the repo
included several directories of documentation and outdated test scripts.

The contents of the PyNGL repository now match what used to be in the
'src' subdirectory, so the build script no longer needs to 'cd src', and
the tests in meta.yaml should run from 'examples', not 'src/examples'.